### PR TITLE
Issue 4 proper handling of k 1 encoding

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -705,8 +705,16 @@ void encode(
   ) {
     // Optimization for 1 erasure (i < k + 1), encoding only targets:
     uint8_t* target = shards[flags_first(targets)];
+    int copied = 0;
     for (int i = 0; i < k + 1; i++) {
-      if (sources & (1 << i)) dot_xor(shards[i], target, shardSize);
+      if (sources & (1 << i)) {
+        if (!copied) {
+          dot_cpy(shards[i], target, shardSize);
+          copied = 1;
+        } else {
+            dot_xor(shards[i], target, shardSize);
+        }
+      }
     }
     return;
   }

--- a/test.js
+++ b/test.js
@@ -317,7 +317,7 @@ queue.onData = function(args, end) {
   );
   var buffer = cipher.update(Buffer.alloc(bufferOffset + bufferSize));
   Assert(buffer.length === bufferOffset + bufferSize);
-  var parity = Buffer.alloc(parityOffset + paritySize);
+  var parity = Node.crypto.randomBytes(parityOffset + paritySize);
   if (parityOffset) {
     Assert(
       cipher.update(Buffer.alloc(parityOffset)).copy(parity, 0) === parityOffset

--- a/test.js
+++ b/test.js
@@ -360,10 +360,6 @@ queue.onData = function(args, end) {
       for (var i = 0; i < k; i++) Assert(Hash(shards[i]) === hashes[i]);
       for (var i = k; i < k + m; i++) hashes[i] = Hash(shards[i]);
       // Test against fixed vector:
-      var key = '';
-      key += String(k).padStart(2, '0') + ',';
-      key += String(m).padStart(2, '0') + ',';
-      key += String(shardSize).padStart(6, '0');
       var result = Hash(hashes.join(','));
       if (regenerate) {
         console.log('  [' +
@@ -764,6 +760,6 @@ queue.concat([
   [24, 5, 13,  9,      8, '4968f6d39f355c41e006b754b436d823'],
   [24, 5,  4, 12,  89816, '93e82c3652f9f963eed72e0d640d9528'],
   [24, 6, 10,  5,      8, '1cd9f45259767305dd7b565bcf9c0359'],
-  [24, 6,  3,  1, 164320, 'f2fad94fdb9e4518728cb0a5a5dbe392']
+  [24, 6,  3,  1, 164320, 'f2fad94fdb9e4518728cb0a5a5dbe392'],
 ]);
 queue.end();


### PR DESCRIPTION
Encoding the single parity of k+1 code is XORing all data parts with the existing, potentially random and uninitialized content of the parity buffer.

Do a copy first, then XOR all the rest.